### PR TITLE
Add example for capture templates

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -103,7 +103,7 @@ Variables:
   * `%?`: Default cursor position when template is opened
 
 Example:<br />
-  `{ T = { description: 'Todo', template: '* TODO %?\n %u', target: '~/org/todo.org' } }`
+  `{ T = { description: 'Todo', template: '* TODO %?\n %u' } }`
 
 #### **org_priority_highest**
 *type*: `string|number`<br />

--- a/DOCS.md
+++ b/DOCS.md
@@ -96,10 +96,14 @@ Example:<br />
 default value: `{ t = { description: 'Task', template: '* TODO %?\n  %u' } }`<br />
 Templates for capture/refile prompt.<br />
 Variables:
-  * `%t`: Prints current date (Example: `<2021-06-10 Thu>`) `%T`: Prints current date and time (Example: `<2021-06-10 Thu 12:30>`)
+  * `%t`: Prints current date (Example: `<2021-06-10 Thu>`)
+  * `%T`: Prints current date and time (Example: `<2021-06-10 Thu 12:30>`)
   * `%u`: Prints current date in inactive format (Example: `[2021-06-10 Thu]`)
   * `%U`: Prints current date and time in inactive format (Example: `[2021-06-10 Thu 12:30]`)
   * `%?`: Default cursor position when template is opened
+
+Example:<br />
+  `{ T = { description: 'Todo', template: '* TODO %?\n %u', target: '~/org/todo.org' } }`
 
 #### **org_priority_highest**
 *type*: `string|number`<br />

--- a/DOCS.md
+++ b/DOCS.md
@@ -103,7 +103,7 @@ Variables:
   * `%?`: Default cursor position when template is opened
 
 Example:<br />
-  `{ T = { description: 'Todo', template: '* TODO %?\n %u' } }`
+  `{ T = { description: 'Todo', template: '* TODO %?\n %u', target: '~/org/todo.org' } }`
 
 #### **org_priority_highest**
 *type*: `string|number`<br />

--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -183,7 +183,8 @@ type: `table<string, table>`
 default value: `{ t = { description: 'Task', template: '* TODO %?\n  %u' } }`
 Templates for capture/refile prompt.
 Variables:
-  * `%t`: Prints current date (Example: `<2021-06-10 Thu>`) `%T`: Prints current date and time (Example: `<2021-06-10 Thu 12:30>`)
+  * `%t`: Prints current date (Example: `<2021-06-10 Thu>`)
+  * `%T`: Prints current date and time (Example: `<2021-06-10 Thu 12:30>`)
   * `%u`: Prints current date in inactive format (Example: `[2021-06-10 Thu]`)
   * `%U`: Prints current date and time in inactive format (Example: `[2021-06-10 Thu 12:30]`)
   * `%?`: Default cursor position when template is opened

--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -189,7 +189,7 @@ Variables:
   * `%U`: Prints current date and time in inactive format (Example: `[2021-06-10 Thu 12:30]`)
   * `%?`: Default cursor position when template is opened
 Example:
-  `{ T = { description: 'Todo', template: '* TODO %?\n %u' } }`
+  `{ T = { description: 'Todo', template: '* TODO %?\n %u', target: '~/org/todo.org' } }`
 
 ORG_PRIORITY_HIGHEST                                *orgmode-org_priority_highest*
 

--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -187,6 +187,8 @@ Variables:
   * `%u`: Prints current date in inactive format (Example: `[2021-06-10 Thu]`)
   * `%U`: Prints current date and time in inactive format (Example: `[2021-06-10 Thu 12:30]`)
   * `%?`: Default cursor position when template is opened
+Example:
+  `{ T = { description: 'Todo', template: '* TODO %?\n %u', target: '~/org/todo.org' } }`
 
 ORG_PRIORITY_HIGHEST                                *orgmode-org_priority_highest*
 

--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -189,7 +189,7 @@ Variables:
   * `%U`: Prints current date and time in inactive format (Example: `[2021-06-10 Thu 12:30]`)
   * `%?`: Default cursor position when template is opened
 Example:
-  `{ T = { description: 'Todo', template: '* TODO %?\n %u', target: '~/org/todo.org' } }`
+  `{ T = { description: 'Todo', template: '* TODO %?\n %u' } }`
 
 ORG_PRIORITY_HIGHEST                                *orgmode-org_priority_highest*
 


### PR DESCRIPTION
The documentation is missing a reference to the target option for a capture template. I was trying to implement it myself but found it was already there. Also fixed a missing newline in the variables list.