### PR TITLE
Add file line number hyperlink

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -101,7 +101,7 @@ Variables:
   * `%T`: Prints current date and time (Example: `<2021-06-10 Thu 12:30>`)
   * `%u`: Prints current date in inactive format (Example: `[2021-06-10 Thu]`)
   * `%U`: Prints current date and time in inactive format (Example: `[2021-06-10 Thu 12:30]`)
-  * `%a`: File from where capture was initiated (Example: `[[file:/home/user/projects/myfile.txt]]`)
+  * `%a`: File and line number from where capture was initiated (Example: `[[file:/home/user/projects/myfile.txt +2]]`)
   * `%?`: Default cursor position when template is opened
 
 Example:<br />
@@ -335,7 +335,8 @@ Toggle current line checkbox state
 Open hyperlink or date under cursor.<br />
 Hyperlink types supported:
 * URL (http://, https://)
-* File (starts with `file:`. Example: `file:/home/user/.config/nvim/init.lua`)
+* File (starts with `file:`. Example: `file:/home/user/.config/nvim/init.lua`) Optionally, a line number can be specified
+using the '+' character. Example: `file:/home/user/.config/nvim/init.lua +10`
 * Headline title target (starts with `*`)
 * Headline with `CUSTOM_ID` property (starts with `#`)
 * Fallback: If file path, opens the file, otherwise, tries to find the Headline title.

--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -189,7 +189,7 @@ Variables:
   * `%T`: Prints current date and time (Example: `<2021-06-10 Thu 12:30>`)
   * `%u`: Prints current date in inactive format (Example: `[2021-06-10 Thu]`)
   * `%U`: Prints current date and time in inactive format (Example: `[2021-06-10 Thu 12:30]`)
-  * `%a`: File from where capture was initiated (Example: `[[file:/home/user/projects/myfile.txt]]`)
+  * `%a`: File and line number from where capture was initiated (Example: `[[file:/home/user/projects/myfile.txt +2]]`)
   * `%?`: Default cursor position when template is opened
 
 Example:
@@ -476,7 +476,8 @@ mapped to: `<Leader>oo`
 Open hyperlink or date under cursor.
 Hyperlink types supported:
 * URL (http://, https://)
-* File (starts with `file:`. Example: `file:/home/user/.config/nvim/init.lua`)
+* File (starts with `file:`. Example: `file:/home/user/.config/nvim/init.lua`) Optionally, a line number can be specified
+using the '+' character. Example: `file:/home/user/.config/nvim/init.lua +10`
 * Headline title target (starts with `*`)
 * Headline with `CUSTOM_ID` property (starts with `#`)
 * Fallback: If file path, opens the file, otherwise, tries to find the Headline title.

--- a/lua/orgmode/capture/templates.lua
+++ b/lua/orgmode/capture/templates.lua
@@ -5,7 +5,8 @@ local expansions = {
   ['%T'] = function() return string.format('<%s>', Date.now():to_string()) end,
   ['%u'] = function() return string.format('[%s]', Date.today():to_string()) end,
   ['%U'] = function() return string.format('[%s]', Date.now():to_string()) end,
-  ['%a'] = function() return string.format('[[file:%s]]', vim.api.nvim_buf_get_name(0)) end,
+  ['%a'] = function() return string.format('[[file:%s +%s]]', vim.api.nvim_buf_get_name(0),
+                                                              vim.api.nvim_win_get_cursor(0)[1]) end,
 }
 
 ---@see https://orgmode.org/manual/Capture-templates.html

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -266,7 +266,13 @@ function OrgMappings:open_at_point()
   local parts = vim.split(link, '][', true)
   local url = parts[1]
   if url:find('^file:') then
-    return vim.cmd(string.format('edit %s', url:sub(6)))
+      if url:find(' +') then
+          parts = vim.split(url, ' +', true)
+          url = parts[1]
+          line_number = parts[2]
+          return vim.cmd(string.format('edit +%s %s', line_number ,url:sub(6)))
+      end
+      return vim.cmd(string.format('edit %s', url:sub(6)))
   end
   if url:find('^https?://') then
     if not vim.g.loaded_netrwPlugin then


### PR DESCRIPTION
In addition to file link, emacs org mode uses the line number in the template. I decided to add it to this org-mode and add the functionality needed to jump to the line number when editing the file.