### PR TITLE
Add capture expansions for journaling

### DIFF
--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -185,17 +185,21 @@ ORG_AGENDA_TEMPLATES                                *orgmode-org_agenda_template
 
 type: `table<string, table>`
 default value: `{ t = { description: 'Task', template: '* TODO %?\n  %u' } }`
-Templates for capture/refile prompt.
+Templates for capture/refile prompt. Use `target =` to specify which file to append to.
 Variables:
   * `%t`: Prints current date (Example: `<2021-06-10 Thu>`)
+  * `%x`: Prints current date without brackets (Example: `2021-06-10`)
+  * `%X`: Prints current time without brackets (Example: `10:20:01`)
   * `%T`: Prints current date and time (Example: `<2021-06-10 Thu 12:30>`)
   * `%u`: Prints current date in inactive format (Example: `[2021-06-10 Thu]`)
+  * `%A`: Prints weekday name (Example: `Wednesday`)
   * `%U`: Prints current date and time in inactive format (Example: `[2021-06-10 Thu 12:30]`)
   * `%a`: File and line number from where capture was initiated (Example: `[[file:/home/user/projects/myfile.txt +2]]`)
   * `%?`: Default cursor position when template is opened
 
 Example:
   `{ T = { description: 'Todo', template: '* TODO %?\n %u', target: '~/org/todo.org' } }`
+  `{ description = 'Journal', template = '\n*** %x %A\n**** %U\n\n%?', target = '~/sync/org/journal.org' }`
 
 ORG_PRIORITY_HIGHEST                                *orgmode-org_priority_highest*
 
@@ -662,4 +666,3 @@ or you can link it to another highlight group:
       hi link OrgAgendaScheduledPast Statement
     endfunction
 <
-

--- a/lua/orgmode/capture/templates.lua
+++ b/lua/orgmode/capture/templates.lua
@@ -1,6 +1,9 @@
 local config = require('orgmode.config')
 local Date = require('orgmode.objects.date')
 local expansions = {
+  ['%A'] = function() return os.date("%A") end,
+  ['%x'] = function() return os.date("%Y-%m-%d") end,
+  ['%X'] = function() return os.date("%X") end,
   ['%t'] = function() return string.format('<%s>', Date.today():to_string()) end,
   ['%T'] = function() return string.format('<%s>', Date.now():to_string()) end,
   ['%u'] = function() return string.format('[%s]', Date.today():to_string()) end,


### PR DESCRIPTION
Adds various capture expansions necessary to generate journal headings, e.g.
```
*** 2021-07-02 Friday
**** [2021-07-02 Fri 08:58]

wowowow it's a journal entry
```
Also documents the `target` option of captures.