### PR TITLE
Set calendar buffer as nonmodifiable

### DIFF
--- a/lua/orgmode/objects/calendar.lua
+++ b/lua/orgmode/objects/calendar.lua
@@ -71,6 +71,8 @@ function Calendar.open()
 end
 
 function Calendar.render()
+  vim.api.nvim_buf_set_option(Calendar.buf, 'modifiable', true)
+
   local first_row = { 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun' }
   local content = { {}, {}, {}, {}, {}, {} }
   local start_weekday = Calendar.month:get_isoweekday()
@@ -112,6 +114,8 @@ function Calendar.render()
       end
     end
   end
+
+  vim.api.nvim_buf_set_option(Calendar.buf, 'modifiable', false)
 end
 
 function Calendar.forward()


### PR DESCRIPTION
Currently users are able to modify the calendar buffer, this can lead to situations where they might accidentally delete parts of the calendar and leave it unusable. Emacs' org mode calendar works a bit differently but it is not editable either. Setting the calendar buffer as not modifiable after rendering it solves the issue.