### PR TITLE
Folded text respects org_hide_leading_stars

### DIFF
--- a/indent/org.vim
+++ b/indent/org.vim
@@ -6,9 +6,13 @@ function! OrgmodeIndentExpr()
   return luaeval('require("orgmode.org.indent").indentexpr()')
 endfunction
 
+function! OrgmodeFoldText()
+  return luaeval('require("orgmode.org.indent").foldtext()')
+endfunction
+
 setlocal foldmethod=expr
 setlocal foldexpr=OrgmodeFoldExpr()
-setlocal foldtext=getline(v:foldstart)
+setlocal foldtext=OrgmodeFoldText()
 setlocal indentexpr=OrgmodeIndentExpr()
 setlocal foldlevel=0
 setlocal nolisp

--- a/lua/orgmode/org/indent.lua
+++ b/lua/orgmode/org/indent.lua
@@ -63,7 +63,16 @@ local function indentexpr()
   return vim.fn.indent(prev_line)
 end
 
+local function foldtext()
+  local line = vim.fn.getline(vim.v.foldstart)
+  if config.org_hide_leading_stars then
+    return vim.fn.substitute(line, '\\(^\\**\\)', '\\=repeat(" ", len(submatch(0))-1) . "*"', '')
+  end
+  return line
+end
+
 return {
   foldexpr = foldexpr,
   indentexpr = indentexpr,
+  foldtext = foldtext,
 }


### PR DESCRIPTION
This commit adds a better ```foldtext``` function that replaces leading stars with spaces when ```org_hide_leading_stars``` is true.

Example without this commit (Lines 2 and 5 are folded):
![2021-08-02-214216_355x140_scrot](https://user-images.githubusercontent.com/1747204/127959161-82517ee1-17d7-491f-be55-54834770ae8f.png)

Same example with this commit:
![2021-08-02-214126_358x140_scrot](https://user-images.githubusercontent.com/1747204/127959179-7f0fd5c3-ea03-41a8-85dd-0b91749df2fb.png)

Thanks