### PR TITLE
bug: rename `itemtag` to `description`

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -235,12 +235,12 @@ function OrgMappings:handle_return(suffix)
     return vim.cmd([[startinsert!]])
   end
 
-  if item.type == 'list' then
+  if item.type == 'list' or item.type == 'listitem' then
     vim.cmd([[normal! ^]])
     item = Files.get_current_file():get_current_node()
   end
 
-  if item.type == 'itemtext' or item.type == 'bullet' or item.type == 'checkbox' or item.type == 'itemtag' then
+  if item.type == 'itemtext' or item.type == 'bullet' or item.type == 'checkbox' or item.type == 'description' then
     local text_edits = {}
     local list_item = item.node:parent()
     if list_item:type() ~= 'listitem' then

--- a/tests/plenary/ui/mappings_spec.lua
+++ b/tests/plenary/ui/mappings_spec.lua
@@ -568,6 +568,47 @@ describe('Mappings', function()
     end
   )
 
+  it('should add a list item with Enter from the description of the list item (org_meta_return)', function()
+    helpers.load_file_content({
+      '#TITLE: Test',
+      '',
+      '* TODO Test orgmode',
+      '  - description :: item',
+    })
+
+    assert.are.same({
+      '  - description :: item',
+    }, vim.api.nvim_buf_get_lines(0, 3, 4, false))
+    vim.fn.cursor(4, 8)
+    vim.cmd([[exe "norm ,\<CR>"]])
+    assert.are.same({
+      '  - description :: item',
+      '  - ',
+    }, vim.api.nvim_buf_get_lines(0, 3, 5, false))
+  end)
+
+  it(
+    'should add a list item with Enter when the cursor is between the bullet and the item (org_meta_return)',
+    function()
+      helpers.load_file_content({
+        '#TITLE: Test',
+        '',
+        '* TODO Test orgmode',
+        '  - item',
+      })
+
+      assert.are.same({
+        '  - item',
+      }, vim.api.nvim_buf_get_lines(0, 3, 4, false))
+      vim.fn.cursor(4, 4)
+      vim.cmd([[exe "norm ,\<CR>"]])
+      assert.are.same({
+        '  - item',
+        '  - ',
+      }, vim.api.nvim_buf_get_lines(0, 3, 5, false))
+    end
+  )
+
   it('should add a list item with Enter skipping over any nested content (org_meta_return)', function()
     helpers.load_file_content({
       '#TITLE: Test',


### PR DESCRIPTION
I forgot to rename this here after I renamed it in tree-sitter-org

Bonus fix, enter in listitems if the cursor is between the bullet and the item

I wrote test cases for both of them.