### PR TITLE
Enhance file: link support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 test:
 	nvim --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedDirectory tests/plenary/ {minimal_init = 'tests/minimal_init.vim'}"
+testfile:
+	nvim --headless --noplugin -u tests/minimal_init.vim -c "PlenaryBustedFile $(FILE)"
 ci:
 	nvim --noplugin -u tests/minimal_init.vim -c "TSUpdateSync org" -c "qa!" && make test
 docs:

--- a/lua/orgmode/org/hyperlinks.lua
+++ b/lua/orgmode/org/hyperlinks.lua
@@ -2,9 +2,62 @@ local Files = require('orgmode.parser.files')
 local utils = require('orgmode.utils')
 local Hyperlinks = {}
 
-function Hyperlinks.find_by_custom_id_property(base, skip_mapping)
-  local headlines = Files.get_current_file():find_headlines_with_property_matching('CUSTOM_ID', base:sub(2))
-  if skip_mapping then
+local function get_file_from_context(ctx)
+  return (
+      ctx.hyperlinks and ctx.hyperlinks.filepath and Files.get(ctx.hyperlinks.filepath, true)
+      or Files.get_current_file()
+    )
+end
+
+local function update_hyperlink_ctx(ctx)
+  if not ctx.line then
+    return
+  end
+
+  -- TODO: Support text search, see here [https://orgmode.org/manual/External-Links.html]
+  local hyperlinks_ctx = {
+    filepath = false,
+    headline = false,
+    custom_id = false,
+  }
+
+  local file_match = ctx.line:match('file:(.-)::')
+  file_match = file_match and vim.fn.fnamemodify(file_match, ':p') or file_match
+
+  if file_match and Files.get(file_match) then
+    hyperlinks_ctx.filepath = Files.get(file_match).filename
+    hyperlinks_ctx.headline = ctx.line:match('file:.-::(%*.-)$')
+
+    if not hyperlinks_ctx.headline then
+      hyperlinks_ctx.custom_id = ctx.line:match('file:.-::(#.-)$')
+    end
+
+    ctx.base = hyperlinks_ctx.headline or hyperlinks_ctx.custom_id or ctx.base
+  end
+
+  ctx.hyperlinks = hyperlinks_ctx
+end
+
+function Hyperlinks.find_by_filepath(ctx)
+  local filenames = Files.filenames()
+  local file_base = ctx.base:gsub('^file:', '')
+  if vim.trim(file_base) ~= '' then
+    filenames = vim.tbl_filter(function(f)
+      return f:find('^' .. file_base)
+    end, filenames)
+  end
+
+  -- Outer checks already filter cases where `ctx.skip_add_prefix` is truthy,
+  -- so no need to check it here
+  return vim.tbl_map(function(path)
+    return 'file:' .. path
+  end, filenames)
+end
+
+function Hyperlinks.find_by_custom_id_property(ctx)
+  local file = get_file_from_context(ctx)
+  local headlines = file:find_headlines_with_property_matching('CUSTOM_ID', ctx.base:sub(2))
+  if ctx.skip_add_prefix then
     return headlines
   end
   return vim.tbl_map(function(headline)
@@ -12,9 +65,10 @@ function Hyperlinks.find_by_custom_id_property(base, skip_mapping)
   end, headlines)
 end
 
-function Hyperlinks.find_by_title_pointer(base, skip_mapping)
-  local headlines = Files.get_current_file():find_headlines_by_title(base:sub(2))
-  if skip_mapping then
+function Hyperlinks.find_by_title_pointer(ctx)
+  local file = get_file_from_context(ctx)
+  local headlines = file:find_headlines_by_title(ctx.base:sub(2))
+  if ctx.skip_add_prefix then
     return headlines
   end
   return vim.tbl_map(function(headline)
@@ -22,13 +76,13 @@ function Hyperlinks.find_by_title_pointer(base, skip_mapping)
   end, headlines)
 end
 
-function Hyperlinks.find_by_dedicated_target(base, skip_mapping)
-  if not base or base == '' then
+function Hyperlinks.find_by_dedicated_target(ctx)
+  if not ctx.base or ctx.base == '' then
     return {}
   end
-  local term = string.format('<<<?(%s[^>]*)>>>?', base):lower()
+  local term = string.format('<<<?(%s[^>]*)>>>?', ctx.base):lower()
   local headlines = Files.get_current_file():find_headlines_matching_search_term(term, true)
-  if skip_mapping then
+  if ctx.skip_add_prefix then
     return headlines
   end
   local targets = {}
@@ -45,12 +99,12 @@ function Hyperlinks.find_by_dedicated_target(base, skip_mapping)
   return targets
 end
 
-function Hyperlinks.find_by_title(base, skip_mapping)
-  if not base or base == '' then
+function Hyperlinks.find_by_title(ctx)
+  if not ctx.base or ctx.base == '' then
     return {}
   end
-  local headlines = Files.get_current_file():find_headlines_by_title(base)
-  if skip_mapping then
+  local headlines = Files.get_current_file():find_headlines_by_title(ctx.base)
+  if ctx.skip_add_prefix then
     return headlines
   end
   return vim.tbl_map(function(headline)
@@ -58,19 +112,26 @@ function Hyperlinks.find_by_title(base, skip_mapping)
   end, headlines)
 end
 
-function Hyperlinks.find_matching_links(base, skip_mapping)
-  base = vim.trim(base)
-  local prefix = base:sub(1, 1)
+function Hyperlinks.find_matching_links(ctx)
+  ctx = ctx or {}
+  ctx.base = ctx.base and vim.trim(ctx.base) or nil
+
+  update_hyperlink_ctx(ctx)
+
+  if ctx.base:find('^file:') and not ctx.skip_add_prefix then
+    return Hyperlinks.find_by_filepath(ctx)
+  end
+
+  local prefix = ctx.base:sub(1, 1)
   if prefix == '#' then
-    return Hyperlinks.find_by_custom_id_property(base, skip_mapping)
+    return Hyperlinks.find_by_custom_id_property(ctx)
   end
-
   if prefix == '*' then
-    return Hyperlinks.find_by_title_pointer(base, skip_mapping)
+    return Hyperlinks.find_by_title_pointer(ctx)
   end
 
-  local results = Hyperlinks.find_by_dedicated_target(base, skip_mapping)
-  local all = utils.concat(results, Hyperlinks.find_by_title(base, skip_mapping))
+  local results = Hyperlinks.find_by_dedicated_target(ctx)
+  local all = utils.concat(results, Hyperlinks.find_by_title(ctx))
   return all
 end
 

--- a/tests/plenary/org/autocompletion_spec.lua
+++ b/tests/plenary/org/autocompletion_spec.lua
@@ -85,6 +85,10 @@ describe('Autocompletion', function()
     result = OrgmodeOmniCompletion(1, '')
     assert.are.same(4, result)
 
+    mock_line(api, '  [[file:')
+    result = OrgmodeOmniCompletion(1, '')
+    assert.are.same(4, result)
+
     mock.revert(api)
   end)
 
@@ -196,7 +200,30 @@ describe('Autocompletion', function()
       { menu = '[Org]', word = ':PRIVATE:' },
     }, result)
 
-    -- TODO: Add hyperlinks test
+    -- TODO: Add more hyperlink tests
+    local MockFiles = mock(Files, true)
+    local filename = 'work.org'
+    local headlines = {
+      { title = 'Item for work 1' },
+      { title = 'Item for work 2' },
+    }
+
+    MockFiles.filenames.returns({ filename })
+    MockFiles.get.returns({
+      filename = filename,
+      find_headlines_by_title = function()
+        return headlines
+      end,
+    })
+
+    mock_line(api, string.format('  [[file:%s::*', filename))
+    result = OrgmodeOmniCompletion(0, '*')
+    assert.are.same({
+      { menu = '[Org]', word = '*' .. headlines[1].title },
+      { menu = '[Org]', word = '*' .. headlines[2].title },
+    }, result)
+
+    mock.revert(MockFiles)
 
     mock.revert(api)
   end)


### PR DESCRIPTION
As a summary:

- Complete org files on 'file:'

https://user-images.githubusercontent.com/31262046/138616359-e4f256f7-af76-4983-b5a1-945f5e56542b.mp4

- Complete headers based on current 'file:' context

https://user-images.githubusercontent.com/31262046/138616389-346f8e01-4d5f-4826-b19c-db7a850834c9.mp4

- Support jumping to specific section in file from hyperlink

https://user-images.githubusercontent.com/31262046/138616420-61c4f986-d2ab-4d07-9a0b-002f05058fa3.mp4

---

For original _Emacs_ functionality, see [here](https://orgmode.org/manual/External-Links.html). I still have some things to review myself and clean up before I would consider this "non-WIP", but the main functionality is there.

