### PR TITLE
Clean up foldtext

### DIFF
--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -22,6 +22,7 @@ function OrgmodeFormatExpr()
   return luaeval('require("orgmode.org.format")()')
 endfunction
 
+setlocal fillchars=fold:\ 
 setlocal foldmethod=expr
 setlocal foldexpr=OrgmodeFoldExpr()
 setlocal foldtext=OrgmodeFoldText()

--- a/lua/orgmode/org/indent.lua
+++ b/lua/orgmode/org/indent.lua
@@ -93,9 +93,9 @@ end
 local function foldtext()
   local line = vim.fn.getline(vim.v.foldstart)
   if config.org_hide_leading_stars then
-    return vim.fn.substitute(line, '\\(^\\**\\)', '\\=repeat(" ", len(submatch(0))-1) . "*"', '')
+    return vim.fn.substitute(line, '\\(^\\**\\)', '\\=repeat(" ", len(submatch(0))-1) . "*"', '') .. '...'
   end
-  return line
+  return line .. '...'
 end
 
 return {


### PR DESCRIPTION
This is just a simple change to make folded headlines look cleaner and more like Emacs's folds

![](https://user-images.githubusercontent.com/79729735/139539971-b86f2014-8a63-4de1-be7a-80d501faedf5.png)
