### PR TITLE
Remove excess `*` in drawer fold text

### DIFF
--- a/lua/orgmode/org/indent.lua
+++ b/lua/orgmode/org/indent.lua
@@ -93,7 +93,7 @@ end
 local function foldtext()
   local line = vim.fn.getline(vim.v.foldstart)
   if config.org_hide_leading_stars then
-    return vim.fn.substitute(line, '\\(^\\**\\)', '\\=repeat(" ", len(submatch(0))-1) . "*"', '') .. '...'
+    return vim.fn.substitute(line, '\\(^\\*+\\)', '\\=repeat(" ", len(submatch(0))-1) . "*"', '') .. '...'
   end
   return line .. '...'
 end


### PR DESCRIPTION
This minor change removes the extra `*` in a folded `:PROPERTIES:` drawer

Before
![](https://user-images.githubusercontent.com/79729735/139558966-312550d9-e8fb-4d22-a0ac-4c0ce12ee9ba.png)

After
![](https://user-images.githubusercontent.com/79729735/139558955-379ba3ca-4cd1-416b-995c-c94361eb2918.png)

