### PR TITLE
Docs update and notification fix

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -133,6 +133,7 @@ vim.cmd[[autocmd ColorScheme * hi link OrgHideLeadingStars MyCustomHlGroup]]
 *type*: `boolean`<br />
 *default value*: `false`<br />
 Conceal bold/italic/underline/code/verbatim markers.
+Ensure your `:h conceallevel` is set properly in order for this to function.
 
 #### **org_log_done**
 *type*: `string|nil`<br />
@@ -899,12 +900,12 @@ require('orgmode').setup({
         local date = string.format('%s: %s', task.type, task.time:to_string())
 
         -- Linux
-        if vim.fn.executable('notify-send') then
+        if vim.fn.executable('notify-send') == 1 then
           vim.loop.spawn('notify-send', { args = { string.format('%s\n%s\n%s', title, subtitle, date) }})
         end
 
         -- MacOS
-        if vim.fn.executable('terminal-notifier') then
+        if vim.fn.executable('terminal-notifier') == 1 then
           vim.loop.spawn('terminal-notifier', { args = { '-title', title, '-subtitle', subtitle, '-message', date }})
         end
       end

--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -283,6 +283,7 @@ ORG_HIDE_EMPHASIS_MARKERS                      *orgmode-org_hide_emphasis_marker
 type: `boolean`
 default value: `false`
 Conceal bold/italic/underline/code/verbatim markers.
+Ensure your `:h conceallevel` is set properly in order for this to function.
 
 ORG_LOG_DONE                                                *orgmode-org_log_done*
 
@@ -1208,11 +1209,11 @@ Default configuration (detailed description below):
             local subtitle = string.format('%s %s %s', string.rep('*', task.level), task.todo, task.title)
             local date = string.format('%s: %s', task.type, task.time:to_string())
             -- Linux
-            if vim.fn.executable('notify-send') then
+            if vim.fn.executable('notify-send') == 1 then
               vim.loop.spawn('notify-send', { args = { string.format('%s\n%s\n%s', title, subtitle, date) }})
             end
             -- MacOS
-            if vim.fn.executable('terminal-notifier') then
+            if vim.fn.executable('terminal-notifier') == 1 then
               vim.loop.spawn('terminal-notifier', { args = { '-title', title, '-subtitle', subtitle, '-message', date }})
             end
           end

--- a/lua/orgmode/notifications/init.lua
+++ b/lua/orgmode/notifications/init.lua
@@ -76,11 +76,11 @@ function Notifications:_cron_notifier(tasks)
     local subtitle = string.format('%s %s %s', string.rep('*', task.level), task.todo, task.title)
     local date = string.format('%s: %s', task.type, task.time:to_string())
 
-    if vim.fn.executable('notify-send') then
+    if vim.fn.executable('notify-send') == 1 then
       vim.loop.spawn('notify-send', { args = { string.format('%s\n%s\n%s', title, subtitle, date) } })
     end
 
-    if vim.fn.executable('terminal-notifier') then
+    if vim.fn.executable('terminal-notifier') == 1 then
       vim.loop.spawn('terminal-notifier', { args = { '-title', title, '-subtitle', subtitle, '-message', date } })
     end
   end


### PR DESCRIPTION
Two changes:

1. Add note in doc. about `conceallevel` being required to hide emphasis markers, "fixes" #124
2. Fix default checks for 0/1 instead of Lua-style boolean for `vim.fn.executable` (used with notifications in this case, but checked elsewhere and other places look good from what I can tell too)