### PR TITLE
docs: Fix duplicate tag when generating :helptags

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -10,7 +10,7 @@
    3. [Capture mappings](#capture-mappings)
    4. [Org mappings](#org-mappings)
    4. [Text objects](#text-objects)
-3. [Diagnostics](#diagnostics)
+3. [Document Diagnostics](#document-diagnostics)
 4. [Autocompletion](#autocompletion)
 5. [Abbreviations](#abbreviations)
 6. [Colors](#colors)
@@ -746,7 +746,7 @@ require('orgmode').setup({
 })
 ```
 
-## Diagnostics
+## Document Diagnostics
 Since tree-sitter parser is being used to parse the file, if there are some syntax errors,
 it can potentially fail to parse specific parts of document when needed. If you are using Neovim v0.6.0 which has
 `vim.diagnostic` available (see `:help vim.diagnostic`), you will get diagnostic errors reported inline.<br />

--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -118,7 +118,7 @@ CONTENTS                                                        *orgmode-content
             1.2.5.6. around_heading_from_root...|orgmode-around_heading_from_root|
             1.2.5.7. inner_subtree_from_root.....|orgmode-inner_subtree_from_root|
             1.2.5.8. around_subtree_from_root...|orgmode-around_subtree_from_root|
-    1.3. Diagnostics.........................................|orgmode-diagnostics|
+    1.3. Document Diagnostics.......................|orgmode-document_diagnostics|
     1.4. Autocompletion...................................|orgmode-autocompletion|
     1.5. Abbreviations.....................................|orgmode-abbreviations|
     1.6. Colors...................................................|orgmode-colors|
@@ -152,7 +152,7 @@ TABLE OF CONTENT                                        *orgmode-table_of_conten
     3.  Capture mappings (#capture-mappings)
     4.  Org mappings (#org-mappings)
     5.  Text objects (#text-objects)
-3.  Diagnostics (#diagnostics)
+3.  Document Diagnostics (#document-diagnostics)
 4.  Autocompletion (#autocompletion)
 5.  Abbreviations (#abbreviations)
 6.  Colors (#colors)
@@ -1048,7 +1048,7 @@ These mappings live under `mappings.text_objects`, and can be changed like this:
 <
 
 --------------------------------------------------------------------------------
-DIAGNOSTICS                                                  *orgmode-diagnostics*
+DOCUMENT DIAGNOSTICS                                *orgmode-document_diagnostics*
 
 Since tree-sitter parser is being used to parse the file, if there are some syntax errors,
 it can potentially fail to parse specific parts of document when needed. If you are using Neovim v0.6.0 which has


### PR DESCRIPTION
Fix #130 