### PR TITLE
feat: add org-ellipsis

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -135,6 +135,11 @@ vim.cmd[[autocmd ColorScheme * hi link OrgHideLeadingStars MyCustomHlGroup]]
 Conceal bold/italic/underline/code/verbatim markers.
 Ensure your `:h conceallevel` is set properly in order for this to function.
 
+#### **org_ellipsis**
+*type*: `string`<br />
+*default value*: `...`<br />
+Marker used to indicate a folded headline.
+
 #### **org_log_done**
 *type*: `string|nil`<br />
 *default value*: `time`<br />

--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -16,11 +16,12 @@ CONTENTS                                                        *orgmode-content
             1.1.1.6. org_archive_location...........|orgmode-org_archive_location|
             1.1.1.7. org_hide_leading_stars.......|orgmode-org_hide_leading_stars|
             1.1.1.8. org_hide_emphasis_markers.|orgmode-org_hide_emphasis_markers|
-            1.1.1.9. org_log_done...........................|orgmode-org_log_done|
-            1.1.1.10. org_highlight_latex_and_related.|orgmode-org_highlight_latex_and_related|
-            1.1.1.11. org_indent_mode....................|orgmode-org_indent_mode|
-            1.1.1.12. org_custom_exports..............|orgmode-org_custom_exports|
-            1.1.1.13. org_time_stamp_rounding_minutes.|orgmode-org_time_stamp_rounding_minutes|
+            1.1.1.9. org_ellipsis...........................|orgmode-org_ellipsis|
+            1.1.1.10. org_log_done...........................|orgmode-org_log_done|
+            1.1.1.11. org_highlight_latex_and_related.|orgmode-org_highlight_latex_and_related|
+            1.1.1.12. org_indent_mode....................|orgmode-org_indent_mode|
+            1.1.1.13. org_custom_exports..............|orgmode-org_custom_exports|
+            1.1.1.14. org_time_stamp_rounding_minutes.|orgmode-org_time_stamp_rounding_minutes|
         1.1.2. Agenda settings...........................|orgmode-agenda_settings|
             1.1.2.1. org_deadline_warning_days.|orgmode-org_deadline_warning_days|
             1.1.2.2. org_agenda_span.....................|orgmode-org_agenda_span|
@@ -284,6 +285,12 @@ type: `boolean`
 default value: `false`
 Conceal bold/italic/underline/code/verbatim markers.
 Ensure your `:h conceallevel` is set properly in order for this to function.
+
+ORG_ELLIPSIS                                                *orgmode-org_ellipsis*
+
+type: `string`
+default value: `...`
+Marker used to indicate folded a headline.
 
 ORG_LOG_DONE                                                *orgmode-org_log_done*
 

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -25,6 +25,7 @@ return {
   org_tags_exclude_from_inheritance = {},
   org_hide_leading_stars = false,
   org_hide_emphasis_markers = false,
+  org_ellipsis = '...',
   org_log_done = 'time',
   org_highlight_latex_and_related = nil,
   org_custom_exports = {},

--- a/lua/orgmode/org/indent.lua
+++ b/lua/orgmode/org/indent.lua
@@ -93,9 +93,9 @@ end
 local function foldtext()
   local line = vim.fn.getline(vim.v.foldstart)
   if config.org_hide_leading_stars then
-    return vim.fn.substitute(line, '\\(^\\*+\\)', '\\=repeat(" ", len(submatch(0))-1) . "*"', '') .. '...'
+    return vim.fn.substitute(line, '\\(^\\*+\\)', '\\=repeat(" ", len(submatch(0))-1) . "*"', '') .. config.org_ellipsis
   end
-  return line .. '...'
+  return line .. config.org_ellipsis
 end
 
 return {


### PR DESCRIPTION
I should have made this configurable from the start but now users can configure what to replace fold markers with. This replicates the `org-ellipsis` setting [available on Emacs](https://emacs.stackexchange.com/a/10986).

Also partially addresses #134