### PR TITLE
Treesitter highlight documentation and default linking

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -849,6 +849,39 @@ endfunction
 
 For adding/changing TODO keyword colors see [org-todo-keyword-faces](#org_todo_keyword_faces)
 
+### Highlight Groups
+
+* The following highlight groups are based on _Treesitter_ query results, hence when setting up _Orgmode_ these
+  highlights must be enabled by removing `disable = {'org'}` from the default recommended _Treesitter_ configuration.
+
+`OrgTSTimestampActive`: An active timestamp
+`OrgTSTimestampInactive`: An inactive timestamp
+`OrgTSBullet`: A normal bullet under a header item
+`OrgTSPropertyDrawer`: Property drawer start/end delimiters
+`OrgTSDrawer`: Drawer start/end delimiters
+`OrgTSTag`: A tag for a headline item, shown on the righthand side like `:foo:`
+`OrgTSPlan`: `SCHEDULED`, `DEADLINE`, `CLOSED`, etc. keywords
+`OrgTSComment`: A comment block
+`OrgTSDirective`: Blocks starting with `#+`
+`OrgTSCheckbox`: The default checkbox highlight, overridden if any of the below groups are specified
+`OrgTSCheckboxChecked`: A checkbox checked with either `[x]` or `[X]`
+`OrgTSCheckboxHalfChecked`: A checkbox checked with `[-]`
+`OrgTSCheckboxUnchecked`: A empty checkbox
+`OrgTSHeadlineLevel1`: Headline at level 1
+`OrgTSHeadlineLevel2`: Headline at level 2
+`OrgTSHeadlineLevel3`: Headline at level 3
+`OrgTSHeadlineLevel4`: Headline at level 4
+`OrgTSHeadlineLevel5`: Headline at level 5
+`OrgTSHeadlineLevel6`: Headline at level 6
+`OrgTSHeadlineLevel7`: Headline at level 7
+`OrgTSHeadlineLevel8`: Headline at level 8
+
+* The following use vanilla _Vim_ syntax matching, and will work without _Treesitter_ highlighting enabled.
+
+`OrgAgendaDeadline`: A item deadline in the agenda view
+`OrgAgendaScheduled`: A scheduled item in the agenda view
+`OrgAgendaScheduledPast`: A item past its scheduled date in the agenda view
+
 ## Advanced search
 Part of [Advanced search](https://orgmode.org/worg/org-tutorials/advanced-searching.html) functionality
 is implemented.

--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -123,6 +123,7 @@ CONTENTS                                                        *orgmode-content
     1.4. Autocompletion...................................|orgmode-autocompletion|
     1.5. Abbreviations.....................................|orgmode-abbreviations|
     1.6. Colors...................................................|orgmode-colors|
+        1.6.1. Highlight Groups.........................|orgmode-highlight_groups|
     1.7. Advanced search.................................|orgmode-advanced_search|
     1.8. Notifications (experimental).......|orgmode-notifications_(experimental)|
         1.8.1. Cron.................................................|orgmode-cron|
@@ -1158,6 +1159,39 @@ or you can link it to another highlight group:
 <
 
 For adding/changing TODO keyword colors see org-todo-keyword-faces (#org_todo_keyword_faces)
+
+HIGHLIGHT GROUPS                                        *orgmode-highlight_groups*
+
+*   The following highlight groups are based on Treesitter query results, hence when setting up Orgmode these
+    highlights must be enabled by removing `disable = {'org'}` from the default recommended Treesitter configuration.
+
+`OrgTSTimestampActive`: An active timestamp
+`OrgTSTimestampInactive`: An inactive timestamp
+`OrgTSBullet`: A normal bullet under a header item
+`OrgTSPropertyDrawer`: Property drawer start/end delimiters
+`OrgTSDrawer`: Drawer start/end delimiters
+`OrgTSTag`: A tag for a headline item, shown on the righthand side like `:foo:`
+`OrgTSPlan`: `SCHEDULED`, `DEADLINE`, `CLOSED`, etc. keywords
+`OrgTSComment`: A comment block
+`OrgTSDirective`: Blocks starting with `#+`
+`OrgTSCheckbox`: The default checkbox highlight, overridden if any of the below groups are specified
+`OrgTSCheckboxChecked`: A checkbox checked with either `[x]` or `[X]`
+`OrgTSCheckboxHalfChecked`: A checkbox checked with `[-]`
+`OrgTSCheckboxUnchecked`: A empty checkbox
+`OrgTSHeadlineLevel1`: Headline at level 1
+`OrgTSHeadlineLevel2`: Headline at level 2
+`OrgTSHeadlineLevel3`: Headline at level 3
+`OrgTSHeadlineLevel4`: Headline at level 4
+`OrgTSHeadlineLevel5`: Headline at level 5
+`OrgTSHeadlineLevel6`: Headline at level 6
+`OrgTSHeadlineLevel7`: Headline at level 7
+`OrgTSHeadlineLevel8`: Headline at level 8
+
+*   The following use vanilla Vim syntax matching, and will work without Treesitter highlighting enabled.
+
+`OrgAgendaDeadline`: A item deadline in the agenda view
+`OrgAgendaScheduled`: A scheduled item in the agenda view
+`OrgAgendaScheduledPast`: A item past its scheduled date in the agenda view
 
 --------------------------------------------------------------------------------
 ADVANCED SEARCH                                          *orgmode-advanced_search*

--- a/lua/orgmode/colors/highlights.lua
+++ b/lua/orgmode/colors/highlights.lua
@@ -4,6 +4,36 @@ local config = require('orgmode.config')
 local colors = require('orgmode.colors')
 local M = {}
 
+function M.link_ts_highlights()
+  local links = {
+    OrgTSTimestampActive = 'PreProc',
+    OrgTSTimestampInactive = 'Comment',
+    OrgTSHeadlineLevel1 = 'OrgHeadlineLevel1',
+    OrgTSHeadlineLevel2 = 'OrgHeadlineLevel2',
+    OrgTSHeadlineLevel3 = 'OrgHeadlineLevel3',
+    OrgTSHeadlineLevel4 = 'OrgHeadlineLevel4',
+    OrgTSHeadlineLevel5 = 'OrgHeadlineLevel5',
+    OrgTSHeadlineLevel6 = 'OrgHeadlineLevel6',
+    OrgTSHeadlineLevel7 = 'OrgHeadlineLevel7',
+    OrgTSHeadlineLevel8 = 'OrgHeadlineLevel8',
+    OrgTSBullet = 'Identifier',
+    OrgTSCheckbox = 'PreProc',
+    OrgTSCheckboxHalfChecked = 'OrgTSCheckbox',
+    OrgTSCheckboxUnchecked = 'OrgTSCheckbox',
+    OrgTSCheckboxChecked = 'OrgTSCheckbox',
+    OrgTSPropertyDrawer = 'Constant',
+    OrgTSDrawer = 'Constant',
+    OrgTSTag = 'Function',
+    OrgTSPlan = 'Constant',
+    OrgTSComment = 'Comment',
+    OrgTSDirective = 'Comment',
+  }
+
+  for src, def in pairs(links) do
+    vim.cmd(string.format([[hi def link %s %s]], src, def))
+  end
+end
+
 function M.define_agenda_colors()
   local keyword_colors = colors.get_todo_keywords_colors()
   local c = {
@@ -88,6 +118,10 @@ function M.define_org_headline_colors(faces)
 end
 
 function M.define_highlights()
+  if config:ts_highlights_enabled() then
+    M.link_ts_highlights()
+  end
+
   local faces = M.define_org_todo_keyword_colors(true)
   return M.define_org_headline_colors(faces)
 end

--- a/queries/org/highlights.scm
+++ b/queries/org/highlights.scm
@@ -1,25 +1,28 @@
-((timestamp) @timestamp (#match? @timestamp "^\\<.*$")) @PreProc
-((timestamp) @timestamp_inactive (#match? @timestamp_inactive "^\\[.*$")) @Comment
+((timestamp) @timestamp (#match? @timestamp "^\\<.*$")) @OrgTSTimestampActive
+((timestamp) @timestamp_inactive (#match? @timestamp_inactive "^\\[.*$")) @OrgTSTimestampInactive
 ; ((markup) @markup_bold (#match? @markup_bold "^\\s*\\*.*\\*$")) @text.strong
 ; ((markup) @markup_italic (#match? @markup_italic "^\\s*\\/.*\\/$")) @text.emphasis
 ; ((markup) @markup_underline (#match? @markup_underline "^\\s*_.*_$")) @TSUnderline
 ; ((markup) @markup_code (#match? @markup_code "^\\s*\\~.*\\~$")) @String
 ; ((markup) @markup_verbatim (#match? @markup_verbatim "^\\s*\\=.*\\=$")) @String
 ; ((markup) @markup_strike (#match? @markup_strike "^\\s*\\+.*\\+$")) @text.strike
-(headline (stars) @stars (#eq? @stars "*")) @OrgHeadlineLevel1
-(headline (stars) @stars (#eq? @stars "**")) @OrgHeadlineLevel2
-(headline (stars) @stars (#eq? @stars "***")) @OrgHeadlineLevel3
-(headline (stars) @stars (#eq? @stars "****")) @OrgHeadlineLevel4
-(headline (stars) @stars (#eq? @stars "*****")) @OrgHeadlineLevel5
-(headline (stars) @stars (#eq? @stars "******")) @OrgHeadlineLevel6
-(headline (stars) @stars (#eq? @stars "*******")) @OrgHeadlineLevel7
-(headline (stars) @stars (#eq? @stars "********")) @OrgHeadlineLevel8
-(bullet) @Identifier
-(checkbox) @PreProc
-(property_drawer) @Constant
-(drawer) @Constant
-(tag) @Function
-(plan) @Constant
-(comment) @Comment
-(directive) @Comment
+(headline (stars) @stars (#eq? @stars "*")) @OrgTSHeadlineLevel1
+(headline (stars) @stars (#eq? @stars "**")) @OrgTSHeadlineLevel2
+(headline (stars) @stars (#eq? @stars "***")) @OrgTSHeadlineLevel3
+(headline (stars) @stars (#eq? @stars "****")) @OrgTSHeadlineLevel4
+(headline (stars) @stars (#eq? @stars "*****")) @OrgTSHeadlineLevel5
+(headline (stars) @stars (#eq? @stars "******")) @OrgTSHeadlineLevel6
+(headline (stars) @stars (#eq? @stars "*******")) @OrgTSHeadlineLevel7
+(headline (stars) @stars (#eq? @stars "********")) @OrgTSHeadlineLevel8
+(bullet) @OrgTSBullet
+(checkbox) @OrgTSCheckbox
+((checkbox) @check (#eq? @check "\[-\]")) @OrgTSCheckboxHalfChecked
+((checkbox) @check (#eq? @check "\[ \]")) @OrgTSCheckboxUnchecked
+((checkbox) @check (#match? @check "\[[xX]\]")) @OrgTSCheckboxChecked
+(property_drawer) @OrgTSPropertyDrawer
+(drawer) @OrgTSDrawer
+(tag) @OrgTSTag
+(plan) @OrgTSPlan
+(comment) @OrgTSComment
+(directive) @OrgTSDirective
 (ERROR) @LspDiagnosticsUnderlineError


### PR DESCRIPTION
Overview:

- Name highlights in Treesitter query file and link them defaults to allow overriding
- Start documentation for highlight groups
- Include "TS" in Treesitter highlights to make it more apparent which are which

with some remaining tasks:

- [x] Finish documentation for highlight groups that are listed but don't have a description
- [x] Add more highlight groups to documentation
- [x] Fix pipeline failures (formatting)

Probably don't need _all_ of the highlight groups present to start, but posting this as a _mostly finished_ draft to get your opinions @kristijanhusak. Any objections to linking things like `org_code` to `OrgCode` highlight groups and similar to follow a similar naming scheme?